### PR TITLE
Refactor Redis package: rename storage.go to fiber_storage.go and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Key features:
 
 The `oauth` package provides OAuth authentication utilities.
 
-[View the OAuth package documentation](./oauth/README.md)
+[View the OAuth package documentation](./oauth/google/README.md)
 
 ### OpenSearch
 
@@ -164,13 +164,14 @@ The `rbac` package provides Role-Based Access Control functionality.
 
 ### Redis
 
-The `redis` package provides a Redis client wrapper for key-value storage.
+The `redis` package provides a Redis client wrapper with connection helpers, healthcheck functionality, and a Fiber storage interface implementation.
 
 Key features:
-- Simple key-value storage interface
-- Support for various Redis client implementations
-- Key expiration support
-- Proper error handling
+- Simple connection helpers with automatic retries
+- Built-in healthcheck function for service readiness probes
+- Environment-based configuration
+- Fiber storage interface implementation for web applications
+- Thread-safe key-value operations
 
 [View the Redis package documentation](./redis/README.md)
 

--- a/redis/README.md
+++ b/redis/README.md
@@ -1,6 +1,6 @@
 # Redis Package
 
-A Go package that provides a simple and configurable Redis client with automatic connection retries and environment variable support.
+A Go package that provides a simple and configurable Redis client with connection helpers, healthcheck functionality, and a Fiber storage interface implementation.
 
 ## Installation
 
@@ -8,7 +8,11 @@ A Go package that provides a simple and configurable Redis client with automatic
 go get github.com/dmitrymomot/gokit/redis
 ```
 
-## Quick Start
+## Primary Features
+
+### Redis Connection
+
+This package provides simplified connection helpers for Redis with automatic retries and robust configuration:
 
 ```go
 import "github.com/dmitrymomot/gokit/redis"
@@ -27,13 +31,25 @@ func main() {
 }
 ```
 
-## Configuration
+### Healthcheck Functionality
+
+The package includes a built-in healthcheck function that can be used for service readiness probes:
+
+```go
+// Using the healthcheck
+healthcheck := redis.Healthcheck(client)
+if err := healthcheck(ctx); err != nil {
+    log.Fatal("Redis healthcheck failed:", err)
+}
+```
+
+### Configuration
 
 The package uses environment variables for configuration and supports `.env` files through `godotenv/autoload`.
 
-### Environment Variables
+#### Environment Variables
 
-The following environment variables are used to configure the Redis client:
+The following environment variables configure the Redis client:
 
 | Environment Variable    | Description                 | Default                    | Required |
 | ----------------------- | --------------------------- | -------------------------- | -------- |
@@ -42,13 +58,74 @@ The following environment variables are used to configure the Redis client:
 | `REDIS_RETRY_INTERVAL`  | Interval between retries    | "5s"                       | No       |
 | `REDIS_CONNECT_TIMEOUT` | Connection timeout duration | "30s"                      | No       |
 
-### Connection URL Format
+## Fiber Storage Interface
 
-The Redis connection URL should be in the following format:
+The package also provides a Redis-based storage implementation that satisfies the Fiber storage interface. This makes it compatible with various Fiber features that require storage capabilities.
 
+### Storage Usage
+
+```go
+import (
+    "github.com/dmitrymomot/gokit/redis"
+    "github.com/gofiber/fiber/v2"
+    "github.com/gofiber/fiber/v2/middleware/session"
+)
+
+func main() {
+    // Create a Redis client
+    client, err := redis.New()
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer client.Close()
+    
+    // Create a Redis-based storage for Fiber
+    storage := redis.NewStorage(client)
+    
+    // Example: Use with session middleware
+    store := session.New(session.Config{
+        Storage: storage,
+    })
+    
+    app := fiber.New()
+    
+    // Use the session middleware as an example
+    app.Use(func(c *fiber.Ctx) error {
+        sess, err := store.Get(c)
+        if err != nil {
+            return err
+        }
+        
+        // Set a value
+        sess.Set("user", "john")
+        
+        // Save the session
+        if err := sess.Save(); err != nil {
+            return err
+        }
+        
+        return c.Next()
+    })
+    
+    // Start server
+    app.Listen(":3000")
+}
 ```
-redis://:password@localhost:6379/0
-```
+
+### Storage Methods
+
+The Redis storage implementation provides the following methods that fulfill the Fiber storage interface:
+
+- `Get(key string) ([]byte, error)`: Retrieve a value by key
+- `Set(key string, val []byte, exp time.Duration) error`: Store a value with optional expiration
+- `Delete(key string) error`: Remove a key-value pair
+- `Reset() error`: Clear all stored data
+- `Close() error`: Close the Redis connection
+
+Additionally, it provides these helper methods:
+
+- `Conn() redis.UniversalClient`: Access the underlying Redis client
+- `Keys() ([][]byte, error)`: Get all keys in the database
 
 ## Error Handling
 
@@ -58,56 +135,6 @@ The package provides several error types for better error handling:
 - `ErrFailedToParseRedisConnString`: Invalid Redis connection string
 - `ErrRedisNotReady`: Redis server not ready within timeout period
 - `ErrHealthcheckFailed`: Redis healthcheck failed
-
-## Features
-
-- Automatic connection retries
-- Environment variable configuration
-- Built-in healthcheck functionality
-- Connection timeout handling
-- `.env` file support
-
-## Example Usage
-
-```go
-package main
-
-import (
-    "context"
-    "log"
-    "time"
-
-    "github.com/dmitrymomot/gokit/redis"
-)
-
-func main() {
-    // Create a new Redis client
-    client, err := redis.New()
-    if err != nil {
-        log.Fatal(err)
-    }
-    defer client.Close()
-
-    // Use the client
-    ctx := context.Background()
-    err = client.Set(ctx, "key", "value", time.Hour).Err()
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    val, err := client.Get(ctx, "key").Result()
-    if err != nil {
-        log.Fatal(err)
-    }
-    log.Printf("Value: %s", val)
-
-    // Using the healthcheck
-    healthcheck := redis.Healthcheck(client)
-    if err := healthcheck(ctx); err != nil {
-        log.Fatal("Redis healthcheck failed:", err)
-    }
-}
-```
 
 ## Dependencies
 

--- a/redis/fiber_storage.go
+++ b/redis/fiber_storage.go
@@ -8,7 +8,8 @@ import (
 )
 
 // Storage is a Redis-based storage implementation that provides a key-value
-// store compatible with various caching and session management interfaces.
+// store compatible with various caching and session management interfaces,
+// including Fiber's session storage interface.
 // It wraps the go-redis client to provide a simplified storage API.
 type Storage struct {
 	db redis.UniversalClient


### PR DESCRIPTION
## Changes

This PR makes the following improvements to the Redis package:

1. Renamed `storage.go` to `fiber_storage.go` to better reflect its purpose as a Fiber storage interface implementation
2. Reorganized the Redis package README.md into two clear sections:
   - Primary Features: Connection helpers and healthcheck functionality
   - Fiber Storage Interface: Redis-based storage implementation for Fiber
3. Updated the main README.md to accurately describe the dual purpose of the Redis package
4. Fixed the OAuth package documentation link in the main README.md

## Motivation

These changes provide better clarity on the Redis package's dual purpose:
1. As a Redis client wrapper with connection helpers and healthcheck
2. As a Fiber-compatible storage implementation

The updated documentation follows the Go development standards with clear organization and comprehensive examples.

## Testing

No functionality changes were made, only renaming and documentation updates.